### PR TITLE
Update workflows

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,23 @@
+[flake8]
+ignore =
+    E265,  # whitespace after '#' (grass module description (fixed in newer versions))
+    E203,  # whitespace before ':' (Black)
+    W503,  # line break before binary operator (Black)
+    E501,  # line too long (161 > 150 characters)
+
+max-line-length = 88
+exclude =
+    .git,
+    __pycache__,
+    .env,
+    .venv,
+    env,
+    venv,
+    ENV,
+    env.bak,
+    venv.bak,
+    ctypes,
+    pydispatch,
+
+builtins =
+    _

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,25 +1,26 @@
 name: Black code style check
 
-on: [push]
+on:
+  - push
+  - pull_request
 
 jobs:
-  black:
-
-    runs-on: ubuntu-18.04
+  run-black:
+    name: Check
+    runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Install apt dependencies
-      run: |
-        sudo apt-get update -qq
-        sudo apt-get install -y -qq python3-pip
-    - name: Add the bin directory pip uses for executables on PATH
-      run: |
-        echo "::add-path::/home/runner/.local/bin"
-    - name: Install pip dependencies
-      run: |
-        python3 -m pip install --upgrade pip
-        pip3 install black
-    - name: Check code style with Black 
-      run: |
-        black --check --diff .
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install black==21.5b1
+      - name: Run Black
+        run: |
+          black --check --diff .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1
@@ -13,19 +13,19 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt-get install -y -qq grass grass-dev grass-doc wget
-    - name: Fix GRASS GIS installation for g.extension (needed for Ubuntu 18.04 grass packages)
+    - name: Fix GRASS GIS installation for g.extension
       run: |
-        wget https://grass.osgeo.org/grass74/manuals/grass_logo.png
-        wget https://grass.osgeo.org/grass74/manuals/grassdocs.css
-        sudo mv grass_logo.png /usr/lib/grass74/docs/html/grass_logo.png
-        sudo mv grassdocs.css /usr/lib/grass74/docs/html/grassdocs.css
-    - name: Create a temporary location (needed for 7.4 and below)
+        wget https://grass.osgeo.org/grass78/manuals/grass_logo.png
+        wget https://grass.osgeo.org/grass78/manuals/grassdocs.css
+        sudo mv grass_logo.png /usr/lib/grass78/docs/html/grass_logo.png
+        sudo mv grassdocs.css /usr/lib/grass78/docs/html/grassdocs.css
+    - name: Create a temporary location
       run: |
         grass -c EPSG:4326 ~/grasstmploc -e
-    - name: Chanage shebang to just Python (7.4 needs python2)
+    - name: Chanage shebang to Python3
       run: |
-        sed -i s/python3/python/g r.example.plus.py
-        sed -i s/python3/python/g testsuite/test_r_example_plus.py
+        sed -i s/python/python3/g r.example.plus.py
+        sed -i s/python/python3/g testsuite/test_r_example_plus.py
     - name: Install the module
       run: |
         grass ~/grasstmploc/PERMANENT --exec g.extension extension=${{ github.event.repository.name }} url=. --verbose
@@ -43,5 +43,5 @@ jobs:
     - name: Run test (manually specified files)
       run: |
         cd testsuite/
-        grass -c ~/nc_spm_08_grass7/test --exec ./test_r_example_plus.py
+        grass -c ~/nc_spm_08_grass7/test --exec python3 ./test_r_example_plus.py
         rm -rf ~/nc_spm_08_grass7/test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
         grass -c EPSG:4326 ~/grasstmploc -e
     - name: Chanage shebang to Python3
       run: |
-        sed -i s/python/python3/g r.example.plus.py
-        sed -i s/python/python3/g testsuite/test_r_example_plus.py
+        sed -i s/python3/python3/g r.example.plus.py
+        sed -i s/python3/python3/g testsuite/test_r_example_plus.py
     - name: Install the module
       run: |
         grass ~/grasstmploc/PERMANENT --exec g.extension extension=${{ github.event.repository.name }} url=. --verbose

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -27,7 +27,7 @@ jobs:
         grass -c EPSG:4326 ~/grasstmploc -e
     - name: Chanage shebang to Python3
       run: |
-        sed -i s/python/python3/g r.example.plus.py
+        sed -i s/python3/python3/g r.example.plus.py
     - name: Install the module to directory called build
       run: |
         grass ~/grasstmploc/PERMANENT --exec g.extension extension=${{ github.event.repository.name }} url=. prefix=build --verbose

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-deploy:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1
@@ -16,18 +16,18 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt-get install -y -qq grass grass-dev grass-doc wget
-    - name: Fix GRASS GIS installation for g.extension (needed for Ubuntu 18.04 grass packages)
+    - name: Fix GRASS GIS installation for g.extension
       run: |
-        wget https://grass.osgeo.org/grass74/manuals/grass_logo.png
-        wget https://grass.osgeo.org/grass74/manuals/grassdocs.css
-        sudo mv grass_logo.png /usr/lib/grass74/docs/html/grass_logo.png
-        sudo mv grassdocs.css /usr/lib/grass74/docs/html/grassdocs.css
-    - name: Create a temporary location (needed for 7.4 and below)
+        wget https://grass.osgeo.org/grass78/manuals/grass_logo.png
+        wget https://grass.osgeo.org/grass78/manuals/grassdocs.css
+        sudo mv grass_logo.png /usr/lib/grass78/docs/html/grass_logo.png
+        sudo mv grassdocs.css /usr/lib/grass78/docs/html/grassdocs.css
+    - name: Create a temporary location
       run: |
         grass -c EPSG:4326 ~/grasstmploc -e
-    - name: Chanage shebang to just Python (7.4 needs python2)
+    - name: Chanage shebang to Python3
       run: |
-        sed -i s/python3/python/g r.example.plus.py
+        sed -i s/python/python3/g r.example.plus.py
     - name: Install the module to directory called build
       run: |
         grass ~/grasstmploc/PERMANENT --exec g.extension extension=${{ github.event.repository.name }} url=. prefix=build --verbose
@@ -35,8 +35,8 @@ jobs:
       run: |
         cp build/docs/html/${{ github.event.repository.name }}.html build/docs/html/index.html
     - name: Deploy
-      uses: peaceiris/actions-gh-pages@v2
+      uses: peaceiris/actions-gh-pages@v2.1.0
       env:
-        ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PUBLISH_BRANCH: gh-pages
         PUBLISH_DIR: ./build/docs/html

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,28 +1,32 @@
 name: Code quality check
 
-on: [push]
+on:
+  - push
+  - pull_request
 
 jobs:
-  lint:
-
-    runs-on: ubuntu-18.04
+  flake8:
+    name: ${{ matrix.directory }}
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        directory:
+          - .
+      fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Install apt dependencies
-      run: |
-        sudo apt-get update -qq
-        sudo apt-get install -y -qq python-pip
-    - name: Add the bin directory pip uses for executables on PATH
-      run: |
-        echo "::add-path::/home/runner/.local/bin"
-    - name: Install pip dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install flake8 pylint
-    - name: Lint with Flake8
-      run: |
-        flake8 --ignore=E265,F821,E501,W503,E203 --max-line-length=88 --count --statistics --show-source .
-    - name: Lint with Pylint
-      run: |
-        pylint --disable=R,bad-continuation,fixme,import-error --additional-builtins=_ --reports=n --score=n -j0 ${{ github.event.repository.name }}.py
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8==3.8.4
+      - name: Run Flake8
+        run: |
+          cd ${{ matrix.directory }}
+          flake8 --count --statistics --show-source --jobs=$(nproc) .

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Once you have the files in place, you need to do some renaming:
 * Rename files to fit the name of your new module.
 * Search all the content of all files for r.example.plus and
   r_example_plus and replace that with your module name.
+* Search all the content of all files for wenzeslaus and
+  replace that with your github user name.
 
 ### Renaming protip
 
@@ -52,6 +54,7 @@ review the changes with git):
 FILES="Makefile *.* */*.* .github/*/*.*"
 sed -i 's/r\.example\.plus/r.minus/g' $FILES
 sed -i 's/r_example_plus/r_minus/g' $FILES
+sed -i 's/wenzeslaus/YOUR_GIHUB_USERNAME/g' $FILES
 ```
 
 ### Getting the GitHub Actions work
@@ -61,11 +64,10 @@ Actions defined in the repository (under `.github`). Initially, most of
 them will fail, but once you do the renaming, most of them should start
 working.
 
-For the workflow uploading documentation to GitHub Pages to
-work, you will need you to
-[set up Deploy key and a Secret](https://github.com/marketplace/actions/github-pages-action#1-add-ssh-deploy-key)
-for your repository. Once the keys are in place, the online documentation
-will be published as GitHub Pages website automatically.
+The workflow for uploading documentation to GitHub Pages should work automatically
+after renaming. However, for the pages to become available, you will need to make the
+repository public (or have an enterprise account). 
+The online documentation will be published as GitHub Pages website automatically.
 The URL for the website is available in the Settings of your repository.
 
 ## Files which usually are not part of a module


### PR DESCRIPTION
With new security policies on github, most workflows fail for new repos that use this template. This PR updates the workflows, also based on configuration from the official GRASS GIS repo. In that context also the GRASS version is updated.
Since this repo is already on Python3 (while GRASS GIS Addons are not yet, The replacement of the shebang could be removed now that GRASS 7.8. is used in CI and building of github pages. Maybe more cleaning could be done?